### PR TITLE
BugFix cubic panaroma image not loaded on correct face

### DIFF
--- a/library/src/main/java/com/panoramagl/loaders/PLJSONLoader.java
+++ b/library/src/main/java/com/panoramagl/loaders/PLJSONLoader.java
@@ -911,7 +911,7 @@ public class PLJSONLoader extends PLLoaderBase
 			super();
 			mPanorama = panorama;
 			mColorFormat = colorFormat;
-			mIndex = 0;
+			mIndex = index;
 		}
 		
 		/**PLFileDownloaderListener methods*/


### PR DESCRIPTION
Cause: Correct index was not assigned to panaroma image in cubic panaroma due to wrong initialization
when the image is loaded from a url