### PR TITLE
Remove obsolete Android checks

### DIFF
--- a/library/src/main/java/com/panoramagl/PLImage.kt
+++ b/library/src/main/java/com/panoramagl/PLImage.kt
@@ -20,7 +20,6 @@ package com.panoramagl
 import android.graphics.*
 import com.panoramagl.ios.structs.CGRect
 import com.panoramagl.ios.structs.CGSize
-import com.panoramagl.utils.getAndroidVersion
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -199,8 +198,6 @@ class PLImage : PLIImage {
 
     protected fun deleteImage() {
         bitmap?.let {
-            if (getAndroidVersion() < 3 && !it.isRecycled)
-                it.recycle()
             isRecycled = true
             isLoaded = false
             bitmap = null

--- a/library/src/main/java/com/panoramagl/PLTexture.kt
+++ b/library/src/main/java/com/panoramagl/PLTexture.kt
@@ -9,7 +9,6 @@ import com.panoramagl.utils.PLLog
 import com.panoramagl.computation.PLMath
 import android.opengl.GLU
 import android.opengl.GLUtils
-import com.panoramagl.utils.getAndroidVersion
 import kotlin.Throws
 
 class PLTexture @JvmOverloads constructor(
@@ -177,15 +176,7 @@ class PLTexture @JvmOverloads constructor(
 
     protected fun recycleTexture(gl: GL10?) {
         if (gl != null && mTextureId[0] != 0) {
-            if (getAndroidVersion() < 3) {
-                gl.glDeleteTextures(1, mTextureId, 0)
-                mTextureId[0] = 0
-                mGLWrapper = null
-                mIsValid = false
-            } else if (mGLWrapper != null) {
-                val glSurfaceView = mGLWrapper?.glSurfaceView
-                glSurfaceView?.queueEvent(PLRecycleTextureRunnable(this))
-            }
+            mGLWrapper?.glSurfaceView?.queueEvent(PLRecycleTextureRunnable(this))
         }
     }
 

--- a/library/src/main/java/com/panoramagl/utils/VersionUtils.kt
+++ b/library/src/main/java/com/panoramagl/utils/VersionUtils.kt
@@ -2,6 +2,4 @@ package com.panoramagl.utils
 
 import android.os.Build
 
-fun getAndroidVersion() = Build.VERSION.RELEASE.trim().split(".")[0].toInt()
-
 fun isEmulator() = Build.PRODUCT.contains("sdk")


### PR DESCRIPTION
We use `minSk 14`, and checks for Android 3 are pointless